### PR TITLE
Apply Material Darker / Material Lighter theme via CSS custom properties

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,11 +4,11 @@ export default function About() {
   return (
     <main className="flex min-h-screen flex-col items-center p-8">
       <div className="max-w-2xl w-full">
-        <Link href="/" className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+        <Link href="/" className="text-sm text-mat-text-muted hover:text-mat-text-secondary">
           &larr; Home
         </Link>
         <h1 className="mt-4 text-3xl font-bold">About</h1>
-        <p className="mt-6 text-gray-600 dark:text-gray-400">
+        <p className="mt-6 text-mat-text-secondary">
           Hi, I&apos;m Pumrapee Poomka. Welcome to my personal website.
         </p>
         <div className="mt-8">
@@ -19,7 +19,7 @@ export default function About() {
                 href="https://github.com/peempumrapee"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline dark:text-blue-400"
+                className="text-mat-link hover:underline"
               >
                 GitHub
               </a>
@@ -29,7 +29,7 @@ export default function About() {
                 href="https://linkedin.com/in/peempumrapee"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline dark:text-blue-400"
+                className="text-mat-link hover:underline"
               >
                 LinkedIn
               </a>
@@ -39,7 +39,7 @@ export default function About() {
                 href="https://twitter.com/peempumrapee"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline dark:text-blue-400"
+                className="text-mat-link hover:underline"
               >
                 Twitter
               </a>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -37,12 +37,12 @@ export default async function BlogPost({
       <article className="max-w-2xl w-full">
         <Link
           href="/blog"
-          className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          className="text-sm text-mat-text-muted hover:text-mat-text-secondary"
         >
           &larr; Blog
         </Link>
         <h1 className="mt-4 text-3xl font-bold">{post.title}</h1>
-        <time className="mt-2 block text-sm text-gray-500 dark:text-gray-400">{post.date}</time>
+        <time className="mt-2 block text-sm text-mat-text-muted">{post.date}</time>
         <div
           className="prose mt-8 max-w-none"
           dangerouslySetInnerHTML={{ __html: content }}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,25 +7,25 @@ export default function Blog() {
   return (
     <main className="flex min-h-screen flex-col items-center p-8">
       <div className="max-w-2xl w-full">
-        <Link href="/" className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+        <Link href="/" className="text-sm text-mat-text-muted hover:text-mat-text-secondary">
           &larr; Home
         </Link>
         <h1 className="mt-4 text-3xl font-bold">Blog</h1>
         {posts.length === 0 ? (
-          <p className="mt-6 text-gray-600 dark:text-gray-400">No posts yet.</p>
+          <p className="mt-6 text-mat-text-secondary">No posts yet.</p>
         ) : (
           <ul className="mt-6 space-y-8">
             {posts.map((post) => (
               <li key={post.slug}>
                 <Link href={`/blog/${post.slug}`} className="group block">
-                  <h2 className="text-xl font-semibold group-hover:text-blue-600 dark:group-hover:text-blue-400">
+                  <h2 className="text-xl font-semibold group-hover:text-mat-link">
                     {post.title}
                   </h2>
-                  <time className="mt-1 block text-sm text-gray-500 dark:text-gray-400">
+                  <time className="mt-1 block text-sm text-mat-text-muted">
                     {post.date}
                   </time>
                   {post.excerpt && (
-                    <p className="mt-2 text-gray-600 dark:text-gray-400">{post.excerpt}</p>
+                    <p className="mt-2 text-mat-text-secondary">{post.excerpt}</p>
                   )}
                 </Link>
               </li>

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -26,7 +26,7 @@ export default function ThemeToggle() {
     <button
       onClick={toggle}
       aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
-      className="rounded-md p-2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+      className="rounded-md p-2 text-mat-text-muted hover:text-mat-text"
     >
       {dark ? (
         <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,43 +2,99 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Dark mode transition for smooth theme switching */
+/* ── Material Theme CSS Custom Properties ── */
+
+/* Material Lighter (light mode – default) */
+:root {
+  --color-bg: #FAFAFA;
+  --color-bg-surface: #F3F4F5;
+  --color-bg-elevated: #E7E7E8;
+  --color-bg-highlight: #E7E7E8;
+  --color-text-primary: #272727;
+  --color-text-secondary: #546E7A;
+  --color-text-muted: #94A7B0;
+  --color-text-faint: #AABFC9;
+  --color-accent: #00BCD4;
+  --color-link: #39ADB5;
+  --color-primary: #6182B8;
+  --color-keyword: #7C4DFF;
+  --color-border: #d3e1e8;
+  --color-error: #e53935;
+}
+
+/* Material Darker (dark mode) */
+.dark {
+  --color-bg: #212121;
+  --color-bg-surface: #2A2A2A;
+  --color-bg-elevated: #323232;
+  --color-bg-highlight: #3F3F3F;
+  --color-text-primary: #eeffff;
+  --color-text-secondary: #B0BEC5;
+  --color-text-muted: #727272;
+  --color-text-faint: #616161;
+  --color-accent: #FF9800;
+  --color-link: #80cbc4;
+  --color-primary: #82aaff;
+  --color-keyword: #c792ea;
+  --color-border: #292929;
+  --color-error: #ff5370;
+}
+
+/* ── Map CSS variables to Tailwind theme tokens ── */
+@theme {
+  --color-mat-bg: var(--color-bg);
+  --color-mat-surface: var(--color-bg-surface);
+  --color-mat-elevated: var(--color-bg-elevated);
+  --color-mat-highlight: var(--color-bg-highlight);
+  --color-mat-text: var(--color-text-primary);
+  --color-mat-text-secondary: var(--color-text-secondary);
+  --color-mat-text-muted: var(--color-text-muted);
+  --color-mat-text-faint: var(--color-text-faint);
+  --color-mat-accent: var(--color-accent);
+  --color-mat-link: var(--color-link);
+  --color-mat-primary: var(--color-primary);
+  --color-mat-keyword: var(--color-keyword);
+  --color-mat-border: var(--color-border);
+  --color-mat-error: var(--color-error);
+}
+
+/* ── Smooth theme transition ── */
 html {
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-/* Dark mode prose styles for markdown content */
-.dark .prose {
-  color: #d1d5db; /* gray-300 */
+/* ── Prose / Markdown styles using Material palette ── */
+.prose {
+  color: var(--color-text-secondary);
 }
-.dark .prose h1,
-.dark .prose h2,
-.dark .prose h3,
-.dark .prose h4,
-.dark .prose h5,
-.dark .prose h6 {
-  color: #f3f4f6; /* gray-100 */
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  color: var(--color-text-primary);
 }
-.dark .prose a {
-  color: #60a5fa; /* blue-400 */
+.prose a {
+  color: var(--color-link);
 }
-.dark .prose strong {
-  color: #f3f4f6; /* gray-100 */
+.prose strong {
+  color: var(--color-text-primary);
 }
-.dark .prose code {
-  color: #f3f4f6; /* gray-100 */
-  background-color: #374151; /* gray-700 */
+.prose code {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-elevated);
 }
-.dark .prose pre {
-  background-color: #1f2937; /* gray-800 */
+.prose pre {
+  background-color: var(--color-bg-surface);
 }
-.dark .prose blockquote {
-  color: #9ca3af; /* gray-400 */
-  border-left-color: #4b5563; /* gray-600 */
+.prose blockquote {
+  color: var(--color-text-muted);
+  border-left-color: var(--color-border);
 }
-.dark .prose hr {
-  border-color: #374151; /* gray-700 */
+.prose hr {
+  border-color: var(--color-border);
 }
-.dark .prose li::marker {
-  color: #9ca3af; /* gray-400 */
+.prose li::marker {
+  color: var(--color-text-muted);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className="bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100"
+        className="bg-mat-bg text-mat-text"
         style={{ fontFamily: "Inter, system-ui, -apple-system, sans-serif" }}
       >
         <div className="fixed top-4 right-4 z-50">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,12 +5,12 @@ export default function NotFound() {
     <main className="flex min-h-screen flex-col items-center justify-center p-8 text-center">
       <h1 className="text-8xl font-bold tracking-tight">404</h1>
       <p className="mt-4 text-xl font-semibold">Page not found :(</p>
-      <p className="mt-2 text-gray-600 dark:text-gray-400">
+      <p className="mt-2 text-mat-text-secondary">
         The requested page could not be found.
       </p>
       <Link
         href="/"
-        className="mt-8 rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-700 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-300"
+        className="mt-8 rounded-md bg-mat-accent px-4 py-2 text-sm font-semibold text-white hover:opacity-80"
       >
         Go Home
       </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,14 +20,14 @@ export default async function Home() {
           <h1 className="text-4xl font-bold tracking-tight sm:text-6xl whitespace-nowrap">
             Peem Pumrapee Poomka
           </h1>
-          <p className="mt-6 text-lg text-gray-600 dark:text-gray-400">
+          <p className="mt-6 text-lg text-mat-text-secondary">
             Software Engineer, Data & Machine Learning Engineering
           </p>
           <div className="mt-4 flex justify-center gap-4">
             <a
               href="mailto:pumrapee2599@gmail.com"
               aria-label="Email"
-              className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              className="text-mat-text-muted hover:text-mat-text"
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="2" y="4" width="20" height="16" rx="2" />
@@ -39,7 +39,7 @@ export default async function Home() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"
-              className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              className="text-mat-text-muted hover:text-mat-text"
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12Z" />
@@ -50,7 +50,7 @@ export default async function Home() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn"
-              className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              className="text-mat-text-muted hover:text-mat-text"
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286ZM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065Zm1.782 13.019H3.555V9h3.564v11.452ZM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003Z" />
@@ -61,7 +61,7 @@ export default async function Home() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="X"
-              className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              className="text-mat-text-muted hover:text-mat-text"
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
@@ -72,16 +72,16 @@ export default async function Home() {
 
         {/* Photo Placeholder */}
         <div className="flex flex-col items-center">
-          <div className="flex h-40 w-40 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-800">
+          <div className="flex h-40 w-40 items-center justify-center rounded-full bg-mat-surface">
             <svg
-              className="h-16 w-16 text-gray-400 dark:text-gray-600"
+              className="h-16 w-16 text-mat-text-faint"
               viewBox="0 0 24 24"
               fill="currentColor"
             >
               <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12Zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v2.4h19.2v-2.4c0-3.2-6.4-4.8-9.6-4.8Z" />
             </svg>
           </div>
-          <p className="mt-3 text-sm text-gray-400 dark:text-gray-500">Add your photo</p>
+          <p className="mt-3 text-sm text-mat-text-faint">Add your photo</p>
         </div>
 
         {/* About Me */}
@@ -97,21 +97,21 @@ export default async function Home() {
         <section>
           <h2 className="text-2xl font-bold">Latest Posts</h2>
           {latestPosts.length === 0 ? (
-            <p className="mt-6 text-gray-600 dark:text-gray-400">No posts yet.</p>
+            <p className="mt-6 text-mat-text-secondary">No posts yet.</p>
           ) : (
             <>
               <ul className="mt-6 space-y-6">
                 {latestPosts.map((post) => (
                   <li key={post.slug}>
                     <Link href={`/blog/${post.slug}`} className="group block">
-                      <h3 className="text-lg font-semibold group-hover:text-blue-600 dark:group-hover:text-blue-400">
+                      <h3 className="text-lg font-semibold group-hover:text-mat-link">
                         {post.title}
                       </h3>
-                      <time className="mt-1 block text-sm text-gray-500 dark:text-gray-400">
+                      <time className="mt-1 block text-sm text-mat-text-muted">
                         {post.date}
                       </time>
                       {post.excerpt && (
-                        <p className="mt-1 text-gray-600 dark:text-gray-400">{post.excerpt}</p>
+                        <p className="mt-1 text-mat-text-secondary">{post.excerpt}</p>
                       )}
                     </Link>
                   </li>
@@ -119,7 +119,7 @@ export default async function Home() {
               </ul>
               <Link
                 href="/blog"
-                className="mt-6 inline-block text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                className="mt-6 inline-block text-sm font-semibold text-mat-link hover:underline"
               >
                 View all posts &rarr;
               </Link>


### PR DESCRIPTION
Replace hardcoded Tailwind gray/blue colors with a CSS variable-based theme system using Material Darker (dark mode) and Material Lighter (light mode) palettes. Variables are defined in globals.css and mapped to Tailwind tokens via @theme, eliminating dark: prefixes from components.