### PR TITLE
fix: patch PostCSS XSS vulnerability (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "remark-rehype": "^11.1.1",
     "unified": "^11.0.5"
   },
+  "pnpm": {
+    "overrides": {
+      "postcss": ">=8.5.10"
+    }
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: '>=8.5.10'
+
 importers:
 
   .:
@@ -949,8 +952,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   property-information@7.1.0:
@@ -1486,7 +1489,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
-      postcss: 8.5.6
+      postcss: 8.5.13
       tailwindcss: 4.1.18
 
   '@types/babel__core@7.20.5':
@@ -2065,7 +2068,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.6:
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2258,7 +2261,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.13
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Summary

- **Vulnerability**: PostCSS moderate XSS via unescaped `</style>` tags in CSS stringify output ([GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93))
- **Affected version**: postcss < 8.5.10 (was 8.5.6 via `@tailwindcss/postcss`)
- **Fix**: Added `pnpm.overrides` in `package.json` to force `postcss >= 8.5.10`; lockfile now resolves to 8.5.13

## Test plan

- [ ] Run `pnpm audit` — should report **no known vulnerabilities**
- [ ] Run `pnpm build` — should complete successfully
- [ ] Verify `pnpm-lock.yaml` contains `postcss@8.5.13`

https://claude.ai/code/session_01DyvZaC5N5sU5zmdSdzi2Mj

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyvZaC5N5sU5zmdSdzi2Mj)_